### PR TITLE
Malformed git checkout causes latest version to be built instead of 1.6

### DIFF
--- a/kube-env-setup.sh
+++ b/kube-env-setup.sh
@@ -27,7 +27,7 @@ tar -xvf go-linux-ppc64le-bootstrap.tbz
 export GOROOT_BOOTSTRAP=/tmp/go-linux-ppc64le-bootstrap
 mkdir -p /go/src/go.googlesource.com && cd /go/src/go.googlesource.com && git clone https://go.googlesource.com/go
 cd /go/src/go.googlesource.com/go/
-git checkout git checkout release-branch.go1.6
+git checkout release-branch.go1.6
 cd src/
 ./make.bash
 cd


### PR DESCRIPTION
Since the git checkout is malformed, it ends up building against the master branch. That currently results in a development version being built:

[root@localhost ppc64le-gc]# /go/src/go.googlesource.com/go/bin/go version
go version devel +de4317c Fri Mar 11 18:25:52 2016 +0000 linux/ppc64le

This change fixes the checkout so it builds 1.6 as expected. 